### PR TITLE
feat: Project/Base/Canonical url utility function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * from "./components/pagination";
 
 // Utilities
 export * from "./utilities/truncateString";
+export * from "./utilities/cannonicalUrl";

--- a/src/utilities/cannonicalUrl/cannonicalUrl.test.ts
+++ b/src/utilities/cannonicalUrl/cannonicalUrl.test.ts
@@ -1,0 +1,10 @@
+import { cannonicalUrl } from "./cannonicalUrl";
+
+describe("Get cannonical url", () => {
+  const exampleUrl = "http://zengenti.com/";
+  const expectedUrl = "https://www.zengenti.com";
+
+  it("Should return the example url with: https enforced, www. added, & trailing / removed", () => {
+    expect(cannonicalUrl(exampleUrl)).toBe(expectedUrl);
+  });
+});

--- a/src/utilities/cannonicalUrl/cannonicalUrl.ts
+++ b/src/utilities/cannonicalUrl/cannonicalUrl.ts
@@ -1,0 +1,12 @@
+export function cannonicalUrl(baseUrl: string) {
+  /** Removes http/https/www protocol from baseUrl */
+  const formatBaseUrl: string = baseUrl.replace(
+    /(http|https):\/\/|www\.|\/$/g,
+    ""
+  );
+
+  /** Formats & enforces https */
+  const buildCannonicalUrl: string = `https://www.${formatBaseUrl}`;
+
+  return buildCannonicalUrl;
+}

--- a/src/utilities/cannonicalUrl/index.ts
+++ b/src/utilities/cannonicalUrl/index.ts
@@ -1,0 +1,1 @@
+export * from "./cannonicalUrl";


### PR DESCRIPTION
This is a utility I'm using to create canonical URLs from the `PUBLIC_URI` in react-starter projects. It's not strictly for canonical URLs, so the naming isn't great, but it's useful as a check to ensure the base URL is set to what we'd expect for SEO purposes, etc.